### PR TITLE
Add appdata XML to flatpak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,6 @@ install:
 	cp org.processing.App.desktop /app/share/applications
 	mkdir -p /app/share/icons/hicolor/128x128/apps
 	cp org.processing.App.png /app/share/icons/hicolor/128x128/apps/
+	mkdir -p /app/share/appdata
+	cp org.processing.App.appdata.xml /app/share/appdata/
 	chmod -R go+rX /app/Processing

--- a/org.processing.App.appdata.xml
+++ b/org.processing.App.appdata.xml
@@ -17,5 +17,4 @@
       <screenshot type="default" width="1248" height="702">https://raw.githubusercontent.com/endlessm/processing-flatpak/master/processing-screenshot.png</screenshot>
   </screenshots>
   <url type="homepage">https://processing.org/</url>
-  <updatecontact>iago@kinvolk.io</updatecontact>
 </component>


### PR DESCRIPTION
We weren't copying the appdata XML to the actual flatpak. Fix that.